### PR TITLE
fix kill_daemons.sh to correctly kill daemons

### DIFF
--- a/kill_daemons.sh
+++ b/kill_daemons.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-pkill -f zerovm 2>/dev/null
+pkill '^zvm\.' 2>/dev/null
 exit 0


### PR DESCRIPTION
changed arguments to pkill to correctly catch zvm daemon process name
