### PR TITLE
libtar symbols fixed

### DIFF
--- a/libports/tar-1.11.8/lib/stpcpy.c
+++ b/libports/tar-1.11.8/lib/stpcpy.c
@@ -22,7 +22,7 @@
 /* Copy SRC to DEST, returning the address of the terminating '\0' in DEST.  */
 
 char *
-stpcpy (dest, src)
+__tar_stpcpy (dest, src)
      char *dest;
      const char *src;
 {

--- a/libports/tar-1.11.8/lib/tarwrapper.c
+++ b/libports/tar-1.11.8/lib/tarwrapper.c
@@ -72,7 +72,7 @@
    -- atoi doesn't.  For now, punt.  FIXME.  */
 
 
-time_t get_date ();
+time_t __tar_get_date ();
 
 /* Local declarations.  */
 
@@ -94,11 +94,11 @@ time_t new_time;
   `-------------------------------------------------------------------------*/
 
 void
-assign_string (char **string, const char *value)
+__tar_assign_string (char **string, const char *value)
 {
     if (*string)
 	free (*string);
-    *string = value ? xstrdup (value) : NULL;
+    *string = value ? __tar_xstrdup (value) : NULL;
 }
 
 /*-----------------------------------------------------------------.
@@ -106,7 +106,7 @@ assign_string (char **string, const char *value)
   `-----------------------------------------------------------------*/
 
 int
-confirm (const char *action, const char *file)
+__tar_confirm (const char *action, const char *file)
 {
     int c, nl;
     static FILE *confirm_file = 0;
@@ -137,7 +137,7 @@ static int name_index = 0;	/* how many of the entries have we scanned? */
   `--------------------------------------------------------------*/
 
 static void
-name_add (const char *name)
+__tar_name_add (const char *name)
 {
     if (names == allocated_names)
 	{
@@ -163,7 +163,7 @@ static size_t name_buffer_length; /* allocated length of name_buffer */
   `-------------------------------------------------------------------------*/
 
 static void
-name_init (int argc, char *const *argv)
+__tar_name_init (int argc, char *const *argv)
 {
     if (flag_namefile)
 	{
@@ -192,7 +192,7 @@ name_init (int argc, char *const *argv)
   `---------------------------------------------------------------------*/
 
 static int
-read_name_from_file (void)
+__tar_read_name_from_file (void)
 {
     register int c;
     register int counter = 0;
@@ -231,7 +231,7 @@ read_name_from_file (void)
   `-------------------------------------------------------------------------*/
 
 char *
-name_next (int change_dirs)
+__tar_name_next (int change_dirs)
 {
     const char *source;
     char *cursor;
@@ -245,7 +245,7 @@ name_next (int change_dirs)
 
 	    /* Read from file.  */
 
-	    while (read_name_from_file ())
+	    while (__tar_read_name_from_file ())
 		if (*name_buffer)	/* ignore emtpy lines */
 		    {
 
@@ -266,9 +266,9 @@ name_next (int change_dirs)
 			    chdir_flag = 1;
 			else
 #if 0
-			    if (!flag_exclude || !check_exclude (name_buffer))
+			    if (!flag_exclude || !__tar_check_exclude (name_buffer))
 #endif
-				return un_quote_string (name_buffer);
+				return __tar_un_quote_string (name_buffer);
 		    }
 
 	    /* No more names in file.  */
@@ -313,9 +313,9 @@ name_next (int change_dirs)
 			chdir_flag = 1;
 		    else
 #if 0
-			if (!flag_exclude || !check_exclude (name_buffer))
+			if (!flag_exclude || !__tar_check_exclude (name_buffer))
 #endif
-			    return un_quote_string (name_buffer);
+			    return __tar_un_quote_string (name_buffer);
 		}
 	}
 
@@ -329,7 +329,7 @@ name_next (int change_dirs)
   `------------------------------*/
 
 void
-name_close (void)
+__tar_name_close (void)
 {
     if (name_file != NULL && name_file != stdin)
 	fclose (name_file);
@@ -340,19 +340,19 @@ name_close (void)
   | care.									   |
   | 									   |
   | If the names are already sorted to match the archive, we just read them  |
-  | one by one.  name_gather reads the first one, and it is called by	   |
-  | name_match as appropriate to read the next ones.  At EOF, the last name  |
+  | one by one.  __tar_name_gather reads the first one, and it is called by	   |
+  | __tar_name_match as appropriate to read the next ones.  At EOF, the last name  |
   | read is just left in the buffer.  This option lets users of small	   |
   | machines extract an arbitrary number of files by doing "tar t" and	   |
   | editing down the list of files.					   |
   `-------------------------------------------------------------------------*/
 
 void
-name_gather (void)
+__tar_name_gather (void)
 {
     register char *p;
     static struct name *namebuf;	/* one-name buffer */
-    static namelen;
+    static int namelen;
     static char *chdir_name = NULL;
 
     if (flag_sorted_names)
@@ -362,13 +362,13 @@ name_gather (void)
 		    namelen = NAMSIZ;
 		    namebuf = (struct name *) tar_xmalloc (sizeof (struct name) + NAMSIZ);
 		}
-	    p = name_next (0);
+	    p = __tar_name_next (0);
 	    if (p)
 		{
 		    if (strcmp (p, "-C") == 0)
 			{
-			    chdir_name = xstrdup (name_next (0));
-			    p = name_next (0);
+			    chdir_name = __tar_xstrdup (__tar_name_next (0));
+			    p = __tar_name_next (0);
 			    if (!p)
 				ERROR ((TAREXIT_FAILURE, 0, _("Missing file name after -C")));
 			    namebuf->change_dir = chdir_name;
@@ -392,8 +392,8 @@ name_gather (void)
 
     /* Non sorted names -- read them all in.  */
 
-    while (p = name_next (0), p)
-	addname (p);
+    while (p = __tar_name_next (0), p)
+	__tar_addname (p);
 }
 
 /*-----------------------------.
@@ -401,7 +401,7 @@ name_gather (void)
   `-----------------------------*/
 
 void
-addname (const char *name)
+__tar_addname (const char *name)
 {
     register int i;		/* length of string */
     register struct name *p;	/* current struct pointer */
@@ -409,8 +409,8 @@ addname (const char *name)
 
     if (strcmp (name, "-C") == 0)
 	{
-	    chdir_name = xstrdup (name_next (0));
-	    name = name_next (0);
+	    chdir_name = __tar_xstrdup (__tar_name_next (0));
+	    name = __tar_name_next (0);
 	    if (!chdir_name)
 		ERROR ((TAREXIT_FAILURE, 0, _("Missing file name after -C")));
 	    if (chdir_name[0] != '/')
@@ -426,7 +426,7 @@ addname (const char *name)
 			ERROR ((TAREXIT_FAILURE, 0,
 				_("Could not get current directory: %s"), path));
 #endif
-		    chdir_name = xstrdup (new_name (path, chdir_name));
+		    chdir_name = __tar_xstrdup (__tar_new_name (path, chdir_name));
 		    free (path);
 		}
 	}
@@ -471,7 +471,7 @@ addname (const char *name)
   `---------------------------------------------------------------------*/
 
 int
-name_match (register const char *p)
+__tar_name_match (register const char *p)
 {
     register struct name *nlp;
     register int len;
@@ -548,7 +548,7 @@ name_match (register const char *p)
 
     if (flag_sorted_names && namelist->found)
 	{
-	    name_gather ();		/* read one more */
+	    __tar_name_gather ();		/* read one more */
 	    if (!namelist->found)
 		goto again;
 	}
@@ -560,7 +560,7 @@ name_match (register const char *p)
   `------------------------------------------------------------------*/
 
 void
-names_notfound (void)
+__tar_names_notfound (void)
 {
     register struct name *nlp, *next;
     register char *p;
@@ -585,7 +585,7 @@ names_notfound (void)
 
     if (flag_sorted_names)
 	{
-	    while (p = name_next (1), p)
+	    while (p = __tar_name_next (1), p)
 		ERROR ((0, 0, _("%s: Not found in archive"), p));
 	}
 }
@@ -597,20 +597,20 @@ names_notfound (void)
   `---*/
 
 void
-name_expand (void)
+__tar_name_expand (void)
 {
     ;
 }
 
 /*------------------------------------------------------------------------.
-  | This is like name_match(), except that it returns a pointer to the name |
+  | This is like __tar_name_match(), except that it returns a pointer to the name |
   | it matched, and doesn't set ->found The caller will have to do that if  |
   | it wants to.  Oh, and if the namelist is empty, it returns 0, unlike	  |
-  | name_match(), which returns TRUE					  |
+  | __tar_name_match(), which returns TRUE					  |
   `------------------------------------------------------------------------*/
 
 struct name *
-name_scan (register const char *p)
+__tar_name_scan (register const char *p)
 {
     register struct name *nlp;
     register int len;
@@ -653,7 +653,7 @@ name_scan (register const char *p)
 
     if (flag_sorted_names && namelist->found)
 	{
-	    name_gather ();		/* read one more */
+	    __tar_name_gather ();		/* read one more */
 	    if (!namelist->found)
 		goto again;
 	}
@@ -669,7 +669,7 @@ name_scan (register const char *p)
 struct name *gnu_list_name;
 
 char *
-name_from_list (void)
+__tar_name_from_list (void)
 {
     if (!gnu_list_name)
 	gnu_list_name = namelist;
@@ -692,7 +692,7 @@ name_from_list (void)
   `---*/
 
 void
-blank_name_list (void)
+__tar_blank_name_list (void)
 {
     struct name *n;
 
@@ -706,7 +706,7 @@ blank_name_list (void)
   `---*/
 
 char *
-new_name (char *path, char *name)
+__tar_new_name (char *path, char *name)
 {
     char *path_buf;
 
@@ -734,7 +734,7 @@ int free_re_exclude = 0;
   `---*/
 
 static int
-is_regex (const char *str)
+__tar_is_regex (const char *str)
 {
     return strchr (str, '*') || strchr (str, '[') || strchr (str, '?');
 }
@@ -744,11 +744,11 @@ is_regex (const char *str)
   `---*/
 
 static void
-add_exclude (char *name)
+__tar_add_exclude (char *name)
 {
     int size_buf;
 
-    un_quote_string (name);
+    __tar_un_quote_string (name);
     size_buf = strlen (name);
 
     if (x_buffer == 0)
@@ -772,7 +772,7 @@ add_exclude (char *name)
 		*tmp_ptr = x_buffer + ((*tmp_ptr) - old_x_buffer);
 	}
 
-    if (is_regex (name))
+    if (__tar_is_regex (name))
 	{
 	    if (free_re_exclude == 0)
 		{
@@ -806,7 +806,7 @@ add_exclude (char *name)
   `---*/
 
 static void
-add_exclude_file (char *file)
+__tar_add_exclude_file (char *file)
 {
     FILE *fp;
     char buf[1024];
@@ -833,7 +833,7 @@ add_exclude_file (char *file)
 	    end_str = strrchr (buf, '\n');
 	    if (end_str)
 		*end_str = '\0';
-	    add_exclude (buf);
+	    __tar_add_exclude (buf);
 
 	}
     fclose (fp);
@@ -844,7 +844,7 @@ add_exclude_file (char *file)
   `--------------------------------------------------------------------*/
 
 int
-check_exclude (const char *name)
+__tar_check_exclude (const char *name)
 {
     int n;
     char *str;
@@ -979,7 +979,7 @@ struct option long_options[] =
   `---------------------------------------------*/
 
 static void
-usage (int status)
+__tar_usage (int status)
 {
     if (status != TAREXIT_SUCCESS)
 	fprintf (stderr, _("Try `%s --help' for more information.\n"),
@@ -1107,7 +1107,7 @@ On *this* particular tar, the defaults are -f %s and -b %d.\n"),
     (command_mode = command_mode == COMMAND_NONE ? (Mode) : COMMAND_TOO_MANY)
 
 static void
-decode_options (int argc, char *const *argv)
+__tar_decode_options (int argc, char *const *argv)
 {
     int optchar;			/* option letter */
 
@@ -1151,7 +1151,7 @@ decode_options (int argc, char *const *argv)
 	    for (letter = *in++; *letter; letter++)
 		{
 		    buffer[1] = *letter;
-		    *out++ = xstrdup (buffer);
+		    *out++ = __tar_xstrdup (buffer);
 		    cursor = strchr (OPTION_STRING, *letter);
 		    if (cursor && cursor[1] == ':')
 			*out++ = *in++;
@@ -1187,20 +1187,20 @@ decode_options (int argc, char *const *argv)
 	    switch (optchar)
 		{
 		case '?':
-		    usage (TAREXIT_FAILURE);
+		    __tar_usage (TAREXIT_FAILURE);
 
 		case 0:
 		    break;
 
 		case 'C':
-		    name_add ("-C");
+		    __tar_name_add ("-C");
 		    /* Fall through.  */
 
 		case 1:
 		    /* File name or non-parsed option, because of RETURN_IN_ORDER
 		       ordering triggerred by the leading dash in OPTION_STRING.  */
 
-		    name_add (optarg);
+		    __tar_name_add (optarg);
 		    break;
 
 		case OPTION_PRESERVE:
@@ -1218,7 +1218,7 @@ decode_options (int argc, char *const *argv)
 		    /* Only write files newer than X.  */
 
 		    flag_new_files++;
-		    new_time = get_date (optarg, (voidstar) 0);
+		    new_time = __tar_get_date (optarg, (voidstar) 0);
 		    if (new_time == (time_t) -1)
 			ERROR ((TAREXIT_FAILURE, 0, _("Invalid date format `%s'"),
 				optarg));
@@ -1231,7 +1231,7 @@ decode_options (int argc, char *const *argv)
 
 		case OPTION_EXCLUDE:
 		    flag_exclude++;
-		    add_exclude (optarg);
+		    __tar_add_exclude (optarg);
 		    break;
 
 		case OPTION_NULL:
@@ -1258,7 +1258,7 @@ decode_options (int argc, char *const *argv)
 		       of the archive, and include in each directory its contents.  */
 
 		    if (flag_oldarch)
-			usage (TAREXIT_FAILURE);
+			__tar_usage (TAREXIT_FAILURE);
 		    flag_gnudump++;
 		    gnu_dumpfile = optarg;
 		    break;
@@ -1314,7 +1314,7 @@ decode_options (int argc, char *const *argv)
 				break;
 
 			    default:
-				usage (TAREXIT_FAILURE);
+				__tar_usage (TAREXIT_FAILURE);
 			    }
 			sprintf (cursor, "%d", device);
 
@@ -1336,7 +1336,7 @@ decode_options (int argc, char *const *argv)
 #else /* not DEVICE_PREFIX */
 
 		    ERROR ((0, 0, _("Options [0-7][lmh] not supported by *this* tar")));
-		    usage (TAREXIT_FAILURE);
+		    __tar_usage (TAREXIT_FAILURE);
 
 #endif /* not DEVICE_PREFIX */
 
@@ -1399,7 +1399,7 @@ decode_options (int argc, char *const *argv)
 		       of the archive, and include in each directory its contents  */
 
 		    if (flag_oldarch)
-			usage (TAREXIT_FAILURE);
+			__tar_usage (TAREXIT_FAILURE);
 		    flag_gnudump++;
 		    gnu_dumpfile = 0;
 		    break;
@@ -1431,7 +1431,7 @@ decode_options (int argc, char *const *argv)
 
 		case 'K':
 		    flag_startfile++;
-		    addname (optarg);
+		    __tar_addname (optarg);
 		    break;
 
 		case 'l':
@@ -1465,7 +1465,7 @@ decode_options (int argc, char *const *argv)
 			|| flag_dironly
 #endif
 			)
-			usage (TAREXIT_FAILURE);
+			__tar_usage (TAREXIT_FAILURE);
 		    flag_oldarch++;
 		    break;
 
@@ -1549,7 +1549,7 @@ decode_options (int argc, char *const *argv)
 
 		case 'X':
 		    flag_exclude++;
-		    add_exclude_file (optarg);
+		    __tar_add_exclude_file (optarg);
 		    break;
 
 		case 'z':
@@ -1580,7 +1580,7 @@ decode_options (int argc, char *const *argv)
 	}
 
     if (show_help)
-	usage (TAREXIT_SUCCESS);
+	__tar_usage (TAREXIT_SUCCESS);
 
     /* Derive option values and check option consistency.  */
 
@@ -1618,28 +1618,28 @@ static void tar_parameters_switcher(){
 	case COMMAND_NONE:
 	    WARN ((0, 0, _("\
 You must specify one of the r, c, t, x, or d options")));
-	    usage (TAREXIT_FAILURE);
+	    __tar_usage (TAREXIT_FAILURE);
 
 	case COMMAND_TOO_MANY:
 	    WARN ((0, 0, _("\
 You may not specify more than one of the r, c, t, x, or d options")));
-	    usage (TAREXIT_FAILURE);
+	    __tar_usage (TAREXIT_FAILURE);
 
 	case COMMAND_CAT:
 	case COMMAND_UPDATE:
 	case COMMAND_APPEND:
 	    DEBUG_PRINT("COMMAND_APPEND");
-	    update_archive ();
+	    __tar_update_archive ();
 	    DEBUG_PRINT("COMMAND_APPEND OK");
 	    break;
 
 	case COMMAND_DELETE:
-	    junk_archive ();
+	    __tar_junk_archive ();
 	    break;
 
 	case COMMAND_CREATE:
 	    DEBUG_PRINT("COMMAND_CREATE");
-	    create_archive ();
+	    __tar_create_archive ();
 	    DEBUG_PRINT("COMMAND_CREATE OK");
 	    if (flag_totals)
 		fprintf (stderr, _("Total bytes written: %d\n"), tot_written);
@@ -1661,8 +1661,8 @@ You may not specify more than one of the r, c, t, x, or d options")));
 			    break;
 			}
 		}
-	    extr_init ();
-	    read_and (extract_archive);
+	    __tar_extr_init ();
+	    __tar_read_and (__tar_extract_archive);
 	    break;
 
 	case COMMAND_LIST:
@@ -1681,7 +1681,7 @@ You may not specify more than one of the r, c, t, x, or d options")));
 			    break;
 			}
 		}
-	    read_and (list_archive);
+	    __tar_read_and (__tar_list_archive);
 #if 0
 	    if (!errors)
 		errors = different;
@@ -1689,8 +1689,8 @@ You may not specify more than one of the r, c, t, x, or d options")));
 	    break;
 
 	case COMMAND_DIFF:
-	    diff_init ();
-	    read_and (diff_archive);
+	    __tar_diff_init ();
+	    __tar_read_and (__tar_diff_archive);
 	    break;
 	}
 }
@@ -1718,12 +1718,12 @@ int save_as_tar(const char *dir_path, const char *tar_path ){
     DEBUG_PRINT(argv[3]);
 
     DEBUG_PRINT("3");
-    decode_options (argc, argv);
+    __tar_decode_options (argc, argv);
     DEBUG_PRINT("4");
 
     if (!names_argv){
 	DEBUG_PRINT("5");
-	name_init (argc, argv);
+	__tar_name_init (argc, argv);
 	DEBUG_PRINT("6");
     }
 
@@ -1731,7 +1731,7 @@ int save_as_tar(const char *dir_path, const char *tar_path ){
     /* Main command execution.  */
     if (flag_volno_file){
 	DEBUG_PRINT("8");
-	init_volume_number ();
+	__tar_init_volume_number ();
 	DEBUG_PRINT("9");
     }
 
@@ -1741,7 +1741,7 @@ int save_as_tar(const char *dir_path, const char *tar_path ){
 
     if (flag_volno_file){
 	DEBUG_PRINT("12");
-	closeout_volume_number ();
+	__tar_closeout_volume_number ();
 	DEBUG_PRINT("13");
     }
 

--- a/libports/tar-1.11.8/lib/xgetcwd.c
+++ b/libports/tar-1.11.8/lib/xgetcwd.c
@@ -47,7 +47,7 @@ void free ();
    Return NULL and set errno on error. */
 
 char *
-xgetcwd ()
+__tar_xgetcwd ()
 {
   char *cwd;
   char *ret;

--- a/libports/tar-1.11.8/lib/xmalloc.c
+++ b/libports/tar-1.11.8/lib/xmalloc.c
@@ -58,7 +58,7 @@ void error ();
 #endif
 
 static VOID *
-fixup_null_alloc (n)
+__tar_fixup_null_alloc (n)
      size_t n;
 {
   VOID *p;
@@ -81,7 +81,7 @@ tar_xmalloc (n)
 
   p = malloc (n);
   if (p == 0)
-    p = fixup_null_alloc (n);
+    p = __tar_fixup_null_alloc (n);
   return p;
 }
 
@@ -98,6 +98,6 @@ tar_realloc (p, n)
     return tar_xmalloc (n);
   p = realloc (p, n);
   if (p == 0)
-    p = fixup_null_alloc (n);
+    p = __tar_fixup_null_alloc (n);
   return p;
 }

--- a/libports/tar-1.11.8/lib/xstrdup.c
+++ b/libports/tar-1.11.8/lib/xstrdup.c
@@ -29,7 +29,7 @@ char *tar_xmalloc ();
 /* Return a newly allocated copy of STRING.  */
 
 char *
-xstrdup (string)
+__tar_xstrdup (string)
      char *string;
 {
   return strcpy (tar_xmalloc (strlen (string) + 1), string);

--- a/libports/tar-1.11.8/src/mangle.c
+++ b/libports/tar-1.11.8/src/mangle.c
@@ -44,7 +44,7 @@ int mangled_num = 0;
 `---*/
 
 void
-extract_mangle (void)
+__tar_extract_mangle (void)
 {
   char *buf;
   char *fromtape;
@@ -59,19 +59,19 @@ extract_mangle (void)
   buf[size] = '\0';
   while (size > 0)
     {
-      fromtape = findrec ()->charptr;
+      fromtape = __tar_findrec ()->charptr;
       if (fromtape == 0)
 	{
 	  ERROR ((0, 0, _("Unexpected EOF in mangled names")));
 	  return;
 	}
-      copied = endofrecs ()->charptr - fromtape;
+      copied = __tar_endofrecs ()->charptr - fromtape;
       if (copied > size)
 	copied = size;
       memcpy (to, fromtape, (size_t) copied);
       to += copied;
       size -= copied;
-      userec ((union record *) (fromtape + copied - 1));
+      __tar_userec ((union record *) (fromtape + copied - 1));
     }
   for (ptr = buf; *ptr; ptr = ptrend)
     {
@@ -90,7 +90,7 @@ extract_mangle (void)
 	  *nam1end = '\0';
 	  if (ptrend[-2] == '/')
 	    ptrend[-2] = '\0';
-	  un_quote_string (nam1end + 4);
+	  __tar_un_quote_string (nam1end + 4);
 	  if (rename (nam1, nam1end + 4))
 	    ERROR ((0, errno, _("Cannot rename %s to %s"), nam1, nam1end + 4));
 	  else if (flag_verbose)
@@ -107,8 +107,8 @@ extract_mangle (void)
 	      nam1end = strchr (nam1end, ' ');
 	    }
 	  *nam1end = '\0';
-	  un_quote_string (nam1);
-	  un_quote_string (nam1end + 4);
+	  __tar_un_quote_string (nam1);
+	  __tar_un_quote_string (nam1end + 4);
 	  if (symlink (nam1, nam1end + 4)
 	      && (unlink (nam1end + 4) || symlink (nam1, nam1end + 4)))
 	    ERROR ((0, errno, _("Cannot symlink %s to %s"),

--- a/libports/tar-1.11.8/src/names.c
+++ b/libports/tar-1.11.8/src/names.c
@@ -60,7 +60,7 @@ static int my_gid = -993;
    pages" code, roughly doubling the program size.  Thanks guys.  */
 
 void
-finduname (char uname[TUNMLEN], int uid)
+__tar_finduname (char uname[TUNMLEN], int uid)
 {
   struct passwd *pw;
 
@@ -81,14 +81,14 @@ finduname (char uname[TUNMLEN], int uid)
 
 #ifdef __native_client__
 int
-finduid (char uname[TUNMLEN])
+__tar_finduid (char uname[TUNMLEN])
 {
     saveuid = myuid;
     return saveuid;
 }
 #else
 int
-finduid (char uname[TUNMLEN])
+__tar_finduid (char uname[TUNMLEN])
 {
   struct passwd *pw;
 
@@ -115,7 +115,7 @@ finduid (char uname[TUNMLEN])
 `---*/
 
 void
-findgname (char gname[TGNMLEN], int gid)
+__tar_findgname (char gname[TGNMLEN], int gid)
 {
 #ifndef __native_client__
   struct group *gr;
@@ -141,7 +141,7 @@ findgname (char gname[TGNMLEN], int gid)
 `---*/
 
 int
-findgid (char gname[TUNMLEN])
+__tar_findgid (char gname[TUNMLEN])
 {
 #ifdef __native_client__
     savegid = mygid;

--- a/libports/tar-1.11.8/src/port.c
+++ b/libports/tar-1.11.8/src/port.c
@@ -465,7 +465,7 @@ utime (char *filename, struct utimbuf *utb)
 `---*/
 
 voidstar
-ck_malloc (size_t size)
+__tar_ck_malloc (size_t size)
 {
   if (!size)
     size++;
@@ -490,7 +490,7 @@ struct buffer
 #define MIN_ALLOCATE 50
 
 char *
-init_buffer (void)
+__tar_init_buffer (void)
 {
   struct buffer *b;
 
@@ -506,7 +506,7 @@ init_buffer (void)
 `---*/
 
 void
-flush_buffer (char *bb)
+__tar_flush_buffer (char *bb)
 {
   struct buffer *b;
 
@@ -523,7 +523,7 @@ flush_buffer (char *bb)
 `---*/
 
 void
-add_buffer (char *bb, const char *p, int n)
+__tar_add_buffer (char *bb, const char *p, int n)
 {
   struct buffer *b;
 
@@ -542,7 +542,7 @@ add_buffer (char *bb, const char *p, int n)
 `---*/
 
 char *
-get_buffer (char *bb)
+__tar_get_buffer (char *bb)
 {
   struct buffer *b;
 
@@ -555,7 +555,7 @@ get_buffer (char *bb)
 `---*/
 
 char *
-merge_sort (char *list, unsigned n, int off, int (*cmp) ())
+__tar_merge_sort (char *list, unsigned n, int off, int (*cmp) ())
 {
   char *ret;
 
@@ -587,8 +587,8 @@ merge_sort (char *list, unsigned n, int off, int (*cmp) ())
   blist = NEXTOF (tptr);
   NEXTOF (tptr) = 0;
 
-  alist = merge_sort (alist, alength, off, cmp);
-  blist = merge_sort (blist, blength, off, cmp);
+  alist = __tar_merge_sort (alist, alength, off, cmp);
+  blist = __tar_merge_sort (blist, blength, off, cmp);
   prev = &ret;
   for (; alist && blist;)
     {
@@ -620,7 +620,7 @@ merge_sort (char *list, unsigned n, int off, int (*cmp) ())
 `---*/
 
 void
-ck_close (int fd)
+__tar_ck_close (int fd)
 {
   if (close (fd) < 0)
     ERROR ((TAREXIT_FAILURE, errno, _("Cannot close a file #%d"), fd));
@@ -637,7 +637,7 @@ ck_close (int fd)
 `-------------------------------------------------------------------------*/
 
 char *
-quote_copy_string (const char *string)
+__tar_quote_copy_string (const char *string)
 {
   const char *from_here;
   char *to_there = NULL;
@@ -720,7 +720,7 @@ quote_copy_string (const char *string)
 /* There is no un-quote-copy-string.  Write it yourself */
 
 char *
-un_quote_string (char *string)
+__tar_un_quote_string (char *string)
 {
   char *ret;
   char *from_here;
@@ -814,7 +814,7 @@ un_quote_string (char *string)
 `---*/
 
 void
-ck_pipe (int *pipes)
+__tar_ck_pipe (int *pipes)
 {
   if (pipe (pipes) < 0)
     ERROR ((TAREXIT_FAILURE, errno, _("Cannot open a pipe")));

--- a/libports/tar-1.11.8/src/rmt.h
+++ b/libports/tar-1.11.8/src/rmt.h
@@ -17,12 +17,12 @@
 
 extern char *__rmt_path;
 
-int __rmt_open __P ((const char *, int, int, const char *));
-int __rmt_close __P ((int));
-int __rmt_read __P ((int, char *, unsigned int));
-int __rmt_write __P ((int, char *, unsigned int));
+int __tar_rmt_open __P ((const char *, int, int, const char *));
+int __tar_rmt_close __P ((int));
+int __tar_rmt_read __P ((int, char *, unsigned int));
+int __tar_rmt_write __P ((int, char *, unsigned int));
 long __rmt_lseek __P ((int, off_t, int));
-int __rmt_ioctl __P ((int, int, char *));
+int __tar_rmt_ioctl __P ((int, int, char *));
 
 /* A filename is remote if it contains a colon not preceeded by a slash,
    to take care of `/:/' which is a shorthand for `/.../<CELL-NAME>/fs'
@@ -46,7 +46,7 @@ int __rmt_ioctl __P ((int, int, char *));
 #endif
 
 #define rmtopen(Path, Oflag, Mode, Command) \
-  (_remdev (Path) ? __rmt_open (Path, Oflag, __REM_BIAS, Command) \
+  (_remdev (Path) ? __tar_rmt_open (Path, Oflag, __REM_BIAS, Command) \
    : open (Path, Oflag, Mode))
 
 #define rmtaccess(Path, Amode) \
@@ -57,29 +57,29 @@ int __rmt_ioctl __P ((int, int, char *));
 
 #define rmtcreat(Path, Mode, Command) \
    (_remdev (Path) \
-    ? __rmt_open (Path, 1 | O_CREAT, __REM_BIAS, Command) \
+    ? __tar_rmt_open (Path, 1 | O_CREAT, __REM_BIAS, Command) \
     : creat (Path, Mode))
 
 #define rmtlstat(Path, Buffer) \
   (_remdev (Path) ? (errno = EOPNOTSUPP), -1 : lstat (Path, Buffer))
 
 #define rmtread(Fd, Buffer, Length) \
-  (_isrmt (Fd) ? __rmt_read (Fd - __REM_BIAS, Buffer, Length) \
+  (_isrmt (Fd) ? __tar_rmt_read (Fd - __REM_BIAS, Buffer, Length) \
    : read (Fd, Buffer, Length))
 
 #define rmtwrite(Fd, Buffer, Length) \
-  (_isrmt (Fd) ? __rmt_write (Fd - __REM_BIAS, Buffer, Length) \
+  (_isrmt (Fd) ? __tar_rmt_write (Fd - __REM_BIAS, Buffer, Length) \
    : write (Fd, Buffer, Length))
 
 #define rmtlseek(Fd, Offset, Where) \
-  (_isrmt (Fd) ? __rmt_lseek (Fd - __REM_BIAS, Offset, Where) \
+  (_isrmt (Fd) ? __tar_rmt_lseek (Fd - __REM_BIAS, Offset, Where) \
    : lseek (Fd, Offset, Where))
 
 #define rmtclose(Fd) \
-  (_isrmt (Fd) ? __rmt_close (Fd - __REM_BIAS) : close (Fd))
+  (_isrmt (Fd) ? __tar_rmt_close (Fd - __REM_BIAS) : close (Fd))
 
 #define rmtioctl(Fd, Request, Argument) \
-  (_isrmt (Fd) ? __rmt_ioctl (Fd - __REM_BIAS, Request, Argument) \
+  (_isrmt (Fd) ? __tar_rmt_ioctl (Fd - __REM_BIAS, Request, Argument) \
    : ioctl (Fd, Request, Argument))
 
 #define rmtdup(Fd) \

--- a/libports/tar-1.11.8/src/tar.h
+++ b/libports/tar-1.11.8/src/tar.h
@@ -358,50 +358,50 @@ extern long save_totsize;
 extern int write_archive_to_stdout;
 
 void close_tar_archive __P ((void));
-void closeout_volume_number __P ((void));
-union record *endofrecs __P ((void));
-union record *findrec __P ((void));
-void fl_read __P ((void));
-void fl_write __P ((void));
-void flush_archive __P ((void));
-void init_volume_number __P ((void));
-int isfile __P ((const char *));
-int no_op __P ((int, char *));
-void open_tar_archive __P ((int));
-void reset_eof __P ((void));
-void saverec __P ((union record **));
-void userec __P ((union record *));
-int wantbytes __P ((long, int (*) ()));
+void __tar_closeout_volume_number __P ((void));
+union record *__tar_endofrecs __P ((void));
+union record *__tar_findrec __P ((void));
+void __tar_fl_read __P ((void));
+void __tar_fl_write __P ((void));
+void __tar_flush_archive __P ((void));
+void __tar_init_volume_number __P ((void));
+int __tar_isfile __P ((const char *));
+int __tar_no_op __P ((int, char *));
+void __tar_open_tar_archive __P ((int));
+void __tar_reset_eof __P ((void));
+void __tar_saverec __P ((union record **));
+void __tar_userec __P ((union record *));
+int __tar_wantbytes __P ((long, int (*) ()));
 
 /* Module create.c.  */
 
-void create_archive __P ((void));
-void dump_file __P ((char *, int, int));
-void finish_header __P ((union record *));
-void to_oct __P ((long, int, char *));
-void write_eot __P ((void));
+void __tar_create_archive __P ((void));
+void __tar_dump_file __P ((char *, int, int));
+void __tar_finish_header __P ((union record *));
+void __tar_to_oct __P ((long, int, char *));
+void __tar_write_eot __P ((void));
 
 /* Module diffarch.c.  */
 
 extern int now_verifying;
 
-void diff_archive __P ((void));
-void diff_init __P ((void));
-void verify_volume __P ((void));
+void __tar_diff_archive __P ((void));
+void __tar_diff_init __P ((void));
+void __tar_verify_volume __P ((void));
 
 /* Module extract.c.  */
 
-void extr_init __P ((void));
-void extract_archive __P ((void));
-void restore_saved_dir_info __P ((void));
+void __tar_extr_init __P ((void));
+void __tar_extract_archive __P ((void));
+void __tar_restore_saved_dir_info __P ((void));
 
 /* Module gnu.c.  */
 
-void collect_and_sort_names __P ((void));
-char *get_dir_contents __P ((char *, int));
-void gnu_restore __P ((int));
-int is_dot_or_dotdot __P ((char *));
-void write_dir_file __P ((void));
+void __tar_collect_and_sort_names __P ((void));
+char *__tar_get_dir_contents __P ((char *, int));
+void __tar_gnu_restore __P ((int));
+int __tar_is_dot_or_dotdot __P ((char *));
+void __tar_write_dir_file __P ((void));
 
 /* Module list.c.  */
 
@@ -409,75 +409,75 @@ extern union record *head;
 extern struct stat hstat;
 extern int head_standard;
 
-void decode_header __P ((union record *, struct stat *, int *, int));
-long from_oct __P ((int, char *));
-void list_archive __P ((void));
-void pr_mkdir __P ((char *, int, int));
-void print_header __P ((void));
-void read_and __P ((void (*do_) ()));
-int read_header __P ((void));
-void skip_extended_headers __P ((void));
-void skip_file __P ((long));
+void __tar_decode_header __P ((union record *, struct stat *, int *, int));
+long __tar_from_oct __P ((int, char *));
+void __tar_list_archive __P ((void));
+void __tar_pr_mkdir __P ((char *, int, int));
+void __tar_print_header __P ((void));
+void __tar_read_and __P ((void (*do_) ()));
+int __tar_read_header __P ((void));
+void __tar_skip_extended_headers __P ((void));
+void __tar_skip_file __P ((long));
 
 /* Module mangle.c.  */
 
-void extract_mangle __P ((void));
+void __tar_extract_mangle __P ((void));
 
 /* Module names.c.  */
 
-int findgid __P ((char gname[TUNMLEN]));
-void findgname __P ((char gname[TGNMLEN], int));
-int finduid __P ((char uname[TUNMLEN]));
-void finduname __P ((char uname[TUNMLEN], int));
+int __tar_findgid __P ((char gname[TUNMLEN]));
+void __tar_findgname __P ((char gname[TGNMLEN], int));
+int __tar_finduid __P ((char uname[TUNMLEN]));
+void __tar_finduname __P ((char uname[TUNMLEN], int));
 
 /* Module port.c.  */
 
 extern char TTY_NAME[];
 
-void add_buffer __P ((char *, const char *, int));
-void ck_close __P ((int));
-voidstar ck_malloc __P ((size_t));
-void ck_pipe __P ((int *));
-void flush_buffer __P ((char *));
-char *get_buffer __P ((char *));
-char *init_buffer __P ((void));
-char *merge_sort __P ((char *, unsigned, int, int (*) ()));
-char *quote_copy_string __P ((const char *));
-char *un_quote_string __P ((char *));
+void __tar_add_buffer __P ((char *, const char *, int));
+void __tar_ck_close __P ((int));
+voidstar __tar_ck_malloc __P ((size_t));
+void __tar_ck_pipe __P ((int *));
+void __tar_flush_buffer __P ((char *));
+char *__tar_get_buffer __P ((char *));
+char *__tar_init_buffer __P ((void));
+char *__tar_merge_sort __P ((char *, unsigned, int, int (*) ()));
+char *__tar_quote_copy_string __P ((const char *));
+char *__tar_un_quote_string __P ((char *));
 
 /* Module rtapelib.c.  */
 
-int __rmt_close __P ((int));
-long __rmt_lseek __P ((int, off_t, int));
-int __rmt_open __P ((const char *, int, int, const char *));
-int __rmt_read __P ((int, char *, unsigned int));
-int __rmt_write __P ((int, char *, unsigned int));
+int __tar_rmt_close __P ((int));
+long __tar_rmt_lseek __P ((int, off_t, int));
+int __tar_rmt_open __P ((const char *, int, int, const char *));
+int __tar_rmt_read __P ((int, char *, unsigned int));
+int __tar_rmt_write __P ((int, char *, unsigned int));
 
 /* Module tar.c.  */
 
 extern time_t new_time;
 
-void addname __P ((const char *));
-void assign_string __P ((char **, const char *));
-void blank_name_list __P ((void));
-int check_exclude __P ((const char *));
-int confirm __P ((const char *, const char *));
-void name_close __P ((void));
-void name_expand __P ((void));
-char *name_from_list __P ((void));
-void name_gather __P ((void));
-int name_match __P ((const char *));
-char *name_next __P ((int change_));
-struct name *name_scan __P ((const char *));
-void names_notfound __P ((void));
-char *new_name __P ((char *, char *));
+void __tar_addname __P ((const char *));
+void __tar_assign_string __P ((char **, const char *));
+void __tar_blank_name_list __P ((void));
+int __tar_check_exclude __P ((const char *));
+int __tar_confirm __P ((const char *, const char *));
+void __tar_name_close __P ((void));
+void __tar_name_expand __P ((void));
+char *__tar_name_from_list __P ((void));
+void __tar_name_gather __P ((void));
+int __tar_name_match __P ((const char *));
+char *__tar_name_next __P ((int change_));
+struct name *__tar_name_scan __P ((const char *));
+void __tar_names_notfound __P ((void));
+char *__tar_new_name __P ((char *, char *));
 
 /* Module update.c.  */
 
 extern char *output_start;
 
-void junk_archive __P ((void));
-void update_archive __P ((void));
+void __tar_junk_archive __P ((void));
+void __tar_update_archive __P ((void));
 
 /*Wrapper tarwrapper.c*/
 /*add directory contents located at dir_path into archive tar_path


### PR DESCRIPTION
Provided unique symbols instead of "common" names, like
"print_header" or "buffer". These symbols frequently clashed with
symbols from other software. Because libtar is a part of ZRT it is
linked to each and every binary.
